### PR TITLE
compatible with Mac xcode environment

### DIFF
--- a/wow.c
+++ b/wow.c
@@ -64,7 +64,7 @@ int check_mac(const char *_mac)
         }
 
         for (i=0; i<6; i++)
-                sscanf(mac_str[i], "%x", &mac[i]);
+                sscanf(mac_str[i], "%hhx", &mac[i]);
 #ifdef _DEBUG
         printf("debug: mac:\n");
         for (i=0; i<6; i++)
@@ -103,7 +103,7 @@ int resolv_name(const char *node, char *ip_str)
 
         addr.s_addr = ((struct sockaddr_in *)(res->ai_addr))->sin_addr.s_addr;
 
-        memset(ip_str, '\0', sizeof(ip_str));
+        memset(ip_str, '\0', sizeof(*ip_str));
         myassert(inet_ntop(AF_INET, &addr, ip_str, 16) != 0, "inet_ntop()\n");
         freeaddrinfo(res);
         printf("%s -> %s\n", node, ip_str);


### PR DESCRIPTION
fix following errors on Mac xcode enviroment
> $ gcc -arch i386 -D_DEBUG wow.c -o wow 
> wow.c:67:42: warning: format specifies type 'unsigned int *' but the argument has type
>       'unsigned char *' [-Wformat]
>                 sscanf(mac_str[i], "%x", &mac[i]);
>                                     ~~   ^~~~~~~
>                                     %s
> wow.c:106:37: warning: 'memset' call operates on objects of type 'char' while the size is based
>       on a different type 'char *' [-Wsizeof-pointer-memaccess]
>         memset(ip_str, '\0', sizeof(ip_str));
>                ~~~~~~               ^~~~~~
> wow.c:106:37: note: did you mean to provide an explicit length?
>         memset(ip_str, '\0', sizeof(ip_str));
>                                     ^~~~~~
> 2 warnings generated.